### PR TITLE
Add share link functionality

### DIFF
--- a/craftparse-norm.js
+++ b/craftparse-norm.js
@@ -9,7 +9,18 @@ document.addEventListener('DOMContentLoaded', function() {
     generateMaterialList();
 	addWarlordToggle();
 	formatedInputNumber();
-	inputActive();
+        inputActive();
+
+    if (urlParams.has('data')) {
+        try {
+            const decoded = JSON.parse(decodeURIComponent(atob(urlParams.get('data'))));
+            setTemplateValues(decoded);
+            const calcBtn = document.querySelector('.calculate-button');
+            if (calcBtn) calcBtn.click();
+        } catch (e) {
+            console.error('Failed to load shared data', e);
+        }
+    }
 	
     // Kun footerin sisällä olevaa SVG:tä painetaan
     document.querySelectorAll('footer svg, #openGiftFromHeader').forEach(element => {
@@ -151,6 +162,21 @@ function createCloseButton(parentElement) {
     closeButton.onclick = closeResults;
     closeButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"/></svg>`;
     parentElement.appendChild(closeButton);
+}
+
+function createShareButton(parentElement, templates) {
+    const shareButton = document.createElement('button');
+    shareButton.id = 'copyLink';
+    shareButton.textContent = 'Copy';
+    shareButton.addEventListener('click', () => {
+        const encoded = btoa(encodeURIComponent(JSON.stringify(templates)));
+        const url = `${window.location.origin}${window.location.pathname}?data=${encoded}`;
+        navigator.clipboard.writeText(url).then(() => {
+            shareButton.textContent = 'Copied!';
+            setTimeout(() => shareButton.textContent = 'Copy', 2000);
+        });
+    });
+    parentElement.appendChild(shareButton);
 }
 
 function createLevelStructure() {
@@ -430,6 +456,15 @@ function calculateMaterials() {
         }
     });
 
+    const shareTemplates = { "1": {}, "5": {}, "10": {} };
+    Object.entries(templateCounts).forEach(([lvl, arr]) => {
+        shareTemplates[lvl] = {};
+        arr.forEach(t => {
+            shareTemplates[lvl][t.name] = t.amount;
+        });
+    });
+
+    createShareButton(resultsDiv, shareTemplates);
     // Lisää sulje-nappi
     createCloseButton(resultsDiv);
     showResults();

--- a/style.css
+++ b/style.css
@@ -127,6 +127,19 @@ footer div {
     background: none;
     width: max-content;
 }
+#copyLink {
+    position: absolute;
+    top: -32px;
+    right: 40px;
+    cursor: pointer;
+    background: var(--primary-color);
+    color: var(--secondary-color);
+    border: none;
+    padding: 10px 15px;
+    text-transform: uppercase;
+    font-weight: bold;
+    border-radius: 4px;
+}
 #results .items {
     margin-bottom: 10px;
     display: flex;


### PR DESCRIPTION
## Summary
- generate shareable crafting results via `Copy` button
- automatically render results when a shared link is opened
- style the copy link button

## Testing
- `node --check craftparse-norm.js`

------
https://chatgpt.com/codex/tasks/task_b_68504bec0b488322802a408a09b05022